### PR TITLE
Fix _get_addr_aligned to properly work with any addr_width

### DIFF
--- a/cocotbext/ahb/ahb_slave.py
+++ b/cocotbext/ahb/ahb_slave.py
@@ -256,16 +256,12 @@ class AHBLiteSlaveRAM(AHBLiteSlave):
         return True
 
     def _get_addr_aligned(self, addr: int) -> int:
-        if self.bus._data_width == 32:
-            if self.bus._addr_width == 32:
-                return addr & 0xFFFF_FFFC
-            elif self.bus._addr_width == 64:
-                return addr & 0xFFFF_FFFF_FFFF_FFFC
-        elif self.bus._data_width == 64:
-            if self.bus._addr_width == 32:
-                return addr & 0xFFFF_FFF8
-            elif self.bus._addr_width == 64:
-                return addr & 0xFFFF_FFFF_FFFF_FFF8
+        def calc_addr_mask(addr_width: int, data_width: int) -> int:
+            import math
+            clog2 = lambda x: math.ceil(math.log2(x))
+            return ((1 << addr_width) - 1) - ((1 << clog2(data_width / 8)) - 1)
+        
+        return calc_addr_mask(self.bus._addr_width, self.bus._data_width) & addr
 
     def _rd(self, addr: int, size: AHBSize) -> int:
         data = self.memory.read(addr, 2**size)


### PR DESCRIPTION
Changed the method _get_addr_aligned in the class AHBLiteSlaveRAM. Previous version didnt work as expected in some cases, for example, when addr_width=16, so I rewrote the method. Now it is able to handle any combination of addr_width and data_width.

In AMBA AHB Specifiation (revision ARM IHI 0033C (ID090921)) "2.2 Manager signals" in Table-2-2 description of HADDR leads next sentence:
> The byte address of the transfer. ADDR_WIDTH
is recommended to be between 10 and 64.
In the issues A and B of this specification, the
address width was fixed at 32.

Therefore, addr_width of 16 is allowed per specification.