### PR TITLE
Fix AHB memory non-full word transactions

### DIFF
--- a/tests/test_ahb_lite_sram_all_sizes.py
+++ b/tests/test_ahb_lite_sram_all_sizes.py
@@ -98,7 +98,7 @@ async def run_test(dut, bp_fn=None, pip_mode=False):
         resp_wr = await ahb_lite_master.write(addr, data, size, pip=pip_mode)
         print(resp_wr)
         expect = sum(
-            (data[i // byte_mode] & mask[index]) << (8 * i)
+            (data[i // byte_mode] & mask[index] << (8 * i))
             for i in range(0, n_bytes, byte_mode)
         )
         resp_rd = await ahb_lite_master.read(address_dw_aligned, pip=pip_mode)


### PR DESCRIPTION
The behavior of non-full word writes and reads in the AHBLiteSlaveRAM class differs from the AHB memory provided by cmsdk (e.g. https://github.com/ForrestBlue/cortexm0ds/blob/master/logical/models/memories/cmsdk_ahb_ram.v). The main difference lies in active byte lanes. For example, in the case of the data bus width of 32 bits, AHBLiteSlaveRAM, when being written a half-word to an address 'h6, expects data to appear in lower bytes of the data bus. While the implementation by cmsdk expects the data in upper bytes. 

I believe that AHBLiteSlaveRAM uses little-endian (because it is the most common).

Furthermore, AMBA AHB Specification (ARM IHI revision 0033C - ID090921) specifies the byte lane output in Table 6-1 in “6.2 Endianess”. It defines which byte lanes are used in HR(HW)DATA.

So I fixed the _rd and _wr methods in the AHBLiteSlaveRAM class. And since the behavior of _rd and _wr methods was changed, tests had to be fixed as well.

Also, the new implementation of _rd and _wr now supports a data bus width different from 32 or 64. The AMBA AHB Specification (ARM IHI revision 0033C (ID090921)) “2.2 Manager signals” Table 2-2 describes HRDATA and HWDATA as such:

> DATA_WIDTH can be 8, 16, 32, 64, 128, 256, 512, or 1024.
> However, any value smaller than 32 or larger than 256 is not recommended.

Therefore, support for other sizes was added to the commit.